### PR TITLE
feat!: Change default 'cause' type to undefined for type safety

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.7",
+  "version": "1.0.0",
   "name": "@nakanoaas/tagged-error",
   "license": "MIT",
   "exports": "./index.ts",

--- a/index.test.ts
+++ b/index.test.ts
@@ -75,7 +75,7 @@ describe("TaggedError in practice", () => {
       result.message,
       "Cannot calculate square root of negative number",
     );
-    assertEquals(result.cause.value, -10);
+    assertEquals(result.cause?.value, -10);
   });
 });
 

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
  * Options for creating a TaggedError
  * @template Cause - The type of the cause data
  */
-interface TaggedErrorOptions<Cause = never> {
+interface TaggedErrorOptions<Cause = undefined> {
   /** Optional error message */
   message?: string;
   /** Optional cause data */
@@ -31,7 +31,7 @@ interface TaggedErrorOptions<Cause = never> {
  * }
  * ```
  */
-export class TaggedError<Tag extends string, Cause = never> extends Error {
+export class TaggedError<Tag extends string, Cause = undefined> extends Error {
   /** The tag identifying the type of error */
   tag: Tag;
   /** The cause data associated with the error */


### PR DESCRIPTION
**BREAKING CHANGE**: The default generic type for the `cause` property in `TaggedError` has been changed from `never` to `undefined`. This may cause type errors in existing code that relies on the previous behavior.

This pull request changes the default generic type for the `cause` property in `TaggedError` from `never` to `undefined`.

#### The Problem

Previously, the default type for `cause` was `never`. This created a type safety issue when creating a union of `TaggedError` types where some instances included a `cause` and others did not.

Consider this union type:

```typescript
type MyError = TaggedError<"TYPE_A"> | TaggedError<"TYPE_B", { value: string }>;
```

With `Cause = never`, the type of the `cause` property for `MyError` was inferred as `never | { value: string }`, which resolves to just `{ value: string }`. This incorrectly suggested that `cause` would always be an object with a `value` property, even for `TaggedError<"TYPE_A">` where `cause` is not provided and is `undefined` at runtime.

This could lead to runtime errors that the TypeScript compiler did not catch:

```typescript
function processError(e: MyError) {
  // This would compile, but throw a runtime error if e.tag is "TYPE_A"
  // because e.cause would be undefined.
  console.log(e.cause.value);
}
```

#### The Solution

By changing the default type to `undefined` (`Cause = undefined`), the `cause` property for the `MyError` union is now correctly inferred as `{ value: string } | undefined`.

This ensures that TypeScript enforces a check for `undefined` before accessing properties on `cause`, thereby preventing runtime errors and improving the overall type safety of the library.

```typescript
function processError(e: MyError) {
  // This now correctly results in a compile-time error.
  // console.log(e.cause.value);

  // Safe access is now enforced.
  if (e.tag === "TYPE_B") {
    // e.cause is now correctly typed as { value: string }
    console.log(e.cause.value);
  }
  // Or by using optional chaining
  console.log(e.cause?.value);
}
```

This change enhances the robustness and reliability of `TaggedError` when used with complex union types.